### PR TITLE
pynacl 1.5.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,9 @@ if [[ ${HOST} =~ .*linux.* ]] && [[ ${ARCH} == 32 ]]; then
     export CFLAGS="$CFLAGS -Og"
 fi
 
+# Define the environment variable LIBSODIUM_MAKE_ARGS to pass arguments to make and enable parallelization
+export LIBSODIUM_MAKE_ARGS="-j4"
+
 export CPPFLAGS="$CPPFLAGS -I${PREFIX}/include"
 export SODIUM_INSTALL="system"
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
+
+# Get an updated config.sub and config.guess
+cp $BUILD_PREFIX/share/gnuconfig/config.* ./src/libsodium/build-aux
+
 if [[ ${HOST} =~ .*linux.* ]] && [[ ${ARCH} == 32 ]]; then
     export CFLAGS="$CFLAGS -Og"
 fi
+
 export CPPFLAGS="$CPPFLAGS -I${PREFIX}/include"
 export SODIUM_INSTALL="system"
+
 python -m pip install . --no-deps --ignore-installed

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,24 +14,25 @@ source:
     - 0001-Fix-name-of-static-sodium-lib.patch
 
 build:
-  number: 1
+  number: 0
+  skip: True  # [py<36]
   ignore_run_exports:  # [win]
     - libsodium        # [win]
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - gnuconfig  # [unix]
+    - m2-patch   # [win]
+    - patch      # [not win]
   host:
     - python
-    - pip
-    - setuptools
-    - wheel
     - cffi >=1.4.1
     - libsodium
     - msinttypes  # [win and vc<14]
-
-  build:
-    - m2-patch    # [win]
-    - {{ compiler('c') }}
-
+    - pip
+    - setuptools >=40.8.0
+    - wheel
   run:
     - python
     - six
@@ -43,11 +44,14 @@ test:
     - nacl.bindings
     - nacl.pwhash
   requires:
-    - pytest >=3.2.1
+    - pip
+    - pytest >=3.2.1,!=3.3.0
     - hypothesis >=3.27.0
   source_files:
     - tests/
   commands:
+    - python -m pip check || true  # [not win]
+    - python -m pip check || exit 1  # [win]
     - pytest
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "PyNaCl" %}
-{% set version = "1.4.0" %}
-{% set sha256 = "54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505" %}
+{% set version = "1.5.0" %}
+{% set sha256 = "8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Update pynacl to 1.5.0

License: https://github.com/pyca/pynacl/blob/1.5.0/LICENSE
Changelog: https://github.com/pyca/pynacl/blob/1.5.0/CHANGELOG.rst
Requirements:
- https://github.com/pyca/pynacl/blob/1.5.0/pyproject.toml
- https://github.com/pyca/pynacl/blob/1.5.0/setup.py

Actions:
1. Update `build.sh`: add `gnuconfig` for osx-arm64 migration, add parallelization for faster wheel build
2. Reset build number to `0`
3. Skip `py<36`
4. Update `build` and `host` dependencies
5. Fix pinning for `pytest` in `test/requires`
6. Add `pip check`